### PR TITLE
Just Fixed the IPAddress Error and Syntax fixes

### DIFF
--- a/RustManager/Forms/Manage.cs
+++ b/RustManager/Forms/Manage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
 using System.Windows.Forms;
@@ -10,6 +10,7 @@ namespace RustManager.Forms
     public partial class Manage : Form
     {
         private static Manage Instance;
+        private object ipAddress;
 
         public Manage()
         {
@@ -43,8 +44,8 @@ namespace RustManager.Forms
                 MessageBox.Show("You must enter a server name.");
                 return;
             }
-
-            if (string.IsNullOrEmpty(AddressBox.Text) || !IPAddress.TryParse(AddressBox.Text, out IPAddress ipAddress))
+            IPAddress ipAddress;
+            if (string.IsNullOrEmpty(AddressBox.Text) || IPAddress.TryParse(AddressBox.Text, out ipAddress))
             {
                 MessageBox.Show("You must enter a (valid) IP address.");
                 return;


### PR DESCRIPTION
IPAddress.TryParse(AddressBox.Text, out IPAddress ipAddress)) To: IPAddress ipAddress; IPAddress.TryParse(AddressBox.Text, out ipAddress))